### PR TITLE
fix: update package name to match other plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import xformCatalogProductVariants from "./utils/xformCatalogProductVariants.js"
 export default async function register(app) {
   await app.registerPlugin({
     label: "Inventory",
-    name: "reaction-inventory",
+    name: "inventory",
     version: app.context.appVersion,
     i18n,
     functionsByType: {


### PR DESCRIPTION
Other package names do not have a `reaction-` prefix. This update syncs this package with all others by removing that.